### PR TITLE
Changning missed call to Client::new() to be self.client

### DIFF
--- a/jupiter-swap-api-client/src/lib.rs
+++ b/jupiter-swap-api-client/src/lib.rs
@@ -44,7 +44,8 @@ impl JupiterSwapApiClient {
         let url = format!("{}/quote", self.base_path);
         let extra_args = quote_request.quote_args.clone();
         let internal_quote_request = InternalQuoteRequest::from(quote_request.clone());
-        let response = Client::new()
+        let response = self
+            .client
             .get(url)
             .query(&internal_quote_request)
             .query(&extra_args)


### PR DESCRIPTION
I do not understand how I missed this in #1 given this is the main endpoint that we use in solgizmo where I tested the change?